### PR TITLE
chore: lefthookで毎回cSpellのチェックをするのを止める

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,5 +5,3 @@ pre-commit:
       run: yarn run lint:eslint
     prettier:
       run: yarn run lint:prettier
-    cspell:
-      run: yarn run lint:cspell


### PR DESCRIPTION
動作が不安定で　遅い